### PR TITLE
compatibility with marginaleffects 0.9.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: etwfe
 Type: Package
 Title: Extended Two-Way Fixed Effects
-Version: 0.2.9001
+Version: 0.2.9002
 Date: 2023-01-24
 Authors@R: 
     c(
@@ -23,7 +23,7 @@ Imports:
   fixest (>= 0.11.0),
   stats,
   Formula,
-  marginaleffects (>= 0.8.1)
+  marginaleffects (>= 0.9.0)
 Suggests:
     did,
     modelsummary,

--- a/R/emfx.R
+++ b/R/emfx.R
@@ -17,8 +17,8 @@
 ##' A potentially useful case is testing whether heterogeneous treatment effects
 ##' (from any `xvar` covariate) are equal by invoking the `hypothesis` argument,
 ##' e.g. `hypothesis = "adult = child"`. 
-##' @return A marginaleffects object.
-##' @seealso [marginaleffects::marginaleffects()]
+##' @return A `slopes` object from the `marginaleffects` package.
+##' @seealso [marginaleffects::slopes()]
 ##' @inherit etwfe return examples
 ##' @export
 emfx = function(
@@ -59,14 +59,21 @@ emfx = function(
     dat[["event"]] = dat[[tvar]] - dat[[gvar]]
     by_var = "event"
   }
-  
-  mfx = marginaleffects::marginaleffects(
+
+  mfx = marginaleffects::slopes(
     object,
     newdata = dat,   
     variables = ".Dtreat",
     by = c(by_var, xvar),
     ...
   )
+
+  # marginaleffects::slopes() sometimes -- but not always -- returns exact zero rows
+  # this code can be removed when this is fixed upstream
+  # https://github.com/vincentarelbundock/marginaleffects/issues/624
+  idx = mfx$estimate != 0 | mfx$std.error != 0
+  mfx = mfx[idx, , drop = FALSE]
+
   
   if (type!="simple") mfx = mfx[order(mfx[[by_var]]),]
    

--- a/inst/tinytest/test_baker.R
+++ b/inst/tinytest/test_baker.R
@@ -11,12 +11,12 @@ baker =
     year       = n + 1980 - 1
     state      = 1 + (id-1) %/% 25
     firms      = runif(id*year, 0, 5)
-    group      = 1 + (state-1) %/% 10
-    treat_date = 1980 + group*6
+    grp        = 1 + (state-1) %/% 10
+    treat_date = 1980 + grp*6
     time_til   = year - treat_date
     treat      = time_til>=0
     e          = rnorm(id*year, 0, 0.5^2)
-    te         = rnorm(id*year, 10-2*(group-1), 0.2^2)
+    te         = rnorm(id*year, 10-2*(grp-1), 0.2^2)
     y          = firms + n + treat*te*(year - treat_date + 1) + e 
     y2         = firms + n + te*treat + e
   })
@@ -78,7 +78,7 @@ bmod_known =
     model_type = "etwfe"
     )
 
-bmod = summary(emfx(
+bmod = emfx(
   etwfe(
     fml  = y ~ 0,
     tvar = year,
@@ -86,7 +86,9 @@ bmod = summary(emfx(
     data = baker,
     vcov = ~id
   ),
-  "event"
-))
+  type = "event"
+)
 
-expect_equal(bmod, bmod_known, tolerance = 1e-6)
+for (col in c("estimate", "std.error", "conf.low", "conf.high", "event")) {
+  expect_equivalent(bmod[[col]], bmod_known[[col]], tolerance = 1e-6)
+}

--- a/inst/tinytest/test_emfx.R
+++ b/inst/tinytest/test_emfx.R
@@ -95,35 +95,35 @@ event_known =
 event_pre_known =
   structure(
     list(
-      type = c("response", "response", "response", "response",
-              "response", "response", "response", "response"), 
-      term = c(".Dtreat", ".Dtreat", ".Dtreat", ".Dtreat",
-               ".Dtreat", ".Dtreat", ".Dtreat", ".Dtreat"),
-      contrast = c("mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)",
-                   "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)"),
-      dydx = c(0, 0, 0, 0,
-               -0.0332122037837577, -0.057345647925759, -0.137870386660868, -0.109539455365126),
-      std.error = c(0, 0, 0, 0,
-                    0.0133686711625469, 0.017153116591293, 0.0307945949146719, 0.0323218247953089),
-      statistic = c(NaN, NaN, NaN, NaN,
-                    -2.48433096901983, -3.34316202076467, -4.47709693999516, -3.38902447676853),
-      p.value = c(NaN, NaN, NaN, NaN,
-                  0.0129795111476838, 0.000828295236610263, 7.56648975457471e-06, 0.000701417491255723),
-      conf.low = c(0, 0, 0, 0, 
-                   -0.0594143177835088, -0.0909651386673097, -0.198226683612125, -0.172889067878545),
-      conf.high = c(0, 0, 0, 0,
-                    -0.00701008978400652, -0.0237261571842083, -0.0775140897096109, -0.0461898428517068),
-      predicted = c(8.58422618817666, 8.55899805002257, 8.59601363947542, 8.59460357323378,
-                    8.55577814211513, 6.00937159256964, 5.31227368284963, 5.38860968779881),
-      predicted_hi = c(8.58422618817666,8.55899805002257, 8.59601363947542, 8.59460357323378,
-                       8.55577814211513, 6.00937159256964, 5.31227368284963, 5.38860968779881), 
-      predicted_lo = c(8.58422618817666, 8.55899805002257, 8.59601363947542, 8.59460357323378,
-                       8.65009313385245, 6.07321374319202, 5.48092092928689, 5.50497348262897),
-      event = c(-4, -3, -2, -1,
-                0, 1, 2, 3)
-    ),
-    class = "data.frame", row.names = c(NA,8L)
-)
+      type = c(
+        "response", "response", "response", "response"
+      ),
+      term = c(".Dtreat", ".Dtreat", ".Dtreat", ".Dtreat"), contrast = c(
+        "mean(TRUE) - mean(FALSE)",
+        "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)"
+      ),
+      estimate = c(
+        -0.0332122037837577, -0.057345647925759, -0.137870386660868,
+        -0.109539455365126),
+      std.error = c(
+        0.0133686711625469, 0.017153116591293,
+        0.0307945949146719, 0.0323218247953089),
+      statistic = c(
+        -2.48433096901983,
+        -3.34316202076467, -4.47709693999516, -3.38902447676853),
+      p.value = c(
+        0.0129795111476838,
+        0.000828295236610263, 7.56648975457471e-06, 0.000701417491255723
+      ),
+      conf.low = c(
+        -0.0594143177835088, -0.0909651386673097, -0.198226683612125,
+        -0.172889067878545),
+      conf.high = c(
+        -0.00701008978400652, -0.0237261571842083,
+        -0.0775140897096109, -0.0461898428517068), event = c(
+        0, 1, 2,
+        3),
+    class = "data.frame", row.names = 5:8))
 
 event_pois_known =
   structure(
@@ -148,11 +148,19 @@ event_pois_known =
   )
 
 # Tests ----
-
-expect_equal(summary(emfx(m3)), simple_known)
-expect_equal(summary(emfx(m3, type = "simple")), simple_known)
-expect_equal(summary(emfx(m3, type = "calendar")), calendar_known)
-expect_equal(summary(emfx(m3, type = "group")), group_known)
-expect_equal(summary(emfx(m3, type = "event")), event_known)
-expect_equal(data.frame(emfx(m3, type = "event", post_only = FALSE)), event_pre_known)
-expect_equal(summary(emfx(m3p, type = "event")), event_pois_known)
+e1 = emfx(m3)
+e2 = emfx(m3, type = "simple")
+e3 = emfx(m3, type = "calendar")
+e4 = emfx(m3, type = "group")
+e5 = emfx(m3, type = "event")
+e6 = emfx(m3, type = "event", post_only = FALSE)
+e7 = emfx(m3p, type = "event")
+for (col in c("estimate", "std.error", "conf.low", "conf.high")) {
+  expect_equivalent(e1[[col]], simple_known[[col]])
+  expect_equivalent(e2[[col]], simple_known[[col]])
+  expect_equivalent(e3[[col]], calendar_known[[col]])
+  expect_equivalent(e4[[col]], group_known[[col]])
+  expect_equivalent(e5[[col]], event_known[[col]])
+  expect_equivalent(e6[[col]], event_pre_known[[col]])
+  expect_equivalent(e7[[col]], event_pois_known[[col]])
+}

--- a/inst/tinytest/test_emfx_xvar.R
+++ b/inst/tinytest/test_emfx_xvar.R
@@ -168,10 +168,20 @@ event_pois_known <-
 
 # Tests ----
 
-expect_equal(summary(emfx(x3)), simple_known)
-expect_equal(summary(emfx(x3, type = "simple")), simple_known)
-expect_equal(summary(emfx(x3, type = "calendar")), calendar_known)
-expect_equal(summary(emfx(x3, type = "group")), group_known)
-expect_equal(summary(emfx(x3, type = "event")), event_known)
-expect_equal(summary(emfx(x3, type = "event", post_only = FALSE)), event_pre_known)
-expect_equal(summary(emfx(x3p, type = "event")), event_pois_known)
+e1 = emfx(x3)
+e2 = emfx(x3, type = "simple")
+e3 = emfx(x3, type = "calendar")
+e4 = emfx(x3, type = "group")
+e5 = emfx(x3, type = "event")
+e6 = emfx(x3, type = "event", post_only = FALSE)
+e7 = emfx(x3p, type = "event")
+for (col in c("estimate", "std.error", "conf.low", "conf.high")) {
+  expect_equivalent(e1[[col]], simple_known[[col]])
+  expect_equivalent(e2[[col]], simple_known[[col]])
+  expect_equivalent(e3[[col]], calendar_known[[col]])
+  expect_equivalent(e4[[col]], group_known[[col]])
+  expect_equivalent(e5[[col]], event_known[[col]])
+  expect_equivalent(e6[[col]], event_pre_known[[col]])
+  expect_equivalent(e7[[col]], event_pois_known[[col]])
+}
+

--- a/man/emfx.Rd
+++ b/man/emfx.Rd
@@ -36,7 +36,7 @@ A potentially useful case is testing whether heterogeneous treatment effects
 e.g. `hypothesis = "adult = child"`.}
 }
 \value{
-A marginaleffects object.
+A `slopes` object from the `marginaleffects` package.
 }
 \description{
 Post-estimation treatment effects for an ETWFE regressions.
@@ -64,5 +64,5 @@ emfx(mod, type = "event")
 
 }
 \seealso{
-[marginaleffects::marginaleffects()]
+[marginaleffects::slopes()]
 }

--- a/vignettes/etwfe.Rmd
+++ b/vignettes/etwfe.Rmd
@@ -209,7 +209,7 @@ theme_set(
   theme_minimal() + theme(panel.grid.minor = element_blank())
 )
 
-ggplot(mod_es, aes(x = event, y = dydx, ymin = conf.low, ymax = conf.high)) +
+ggplot(mod_es, aes(x = event, y = estimate, ymin = conf.low, ymax = conf.high)) +
   geom_hline(yintercept = 0) +
   geom_pointrange(col = "darkcyan") +
   labs(x = "Years post treatment", y = "Effect on log employment")
@@ -229,7 +229,7 @@ pleasing.
 # Use post_only = FALSE to get the "zero" pre-treatment effects
 mod_es2 = emfx(mod, type = "event", post_only = FALSE)
 
-ggplot(mod_es2, aes(x = event, y = dydx, ymin = conf.low, ymax = conf.high)) +
+ggplot(mod_es2, aes(x = event, y = estimate, ymin = conf.low, ymax = conf.high)) +
   geom_hline(yintercept = 0) +
   geom_vline(xintercept = -1, lty = 2) +
   geom_pointrange(col = "darkcyan") +


### PR DESCRIPTION
Apologies for the trouble, but version 0.9.0 of `marginaleffects` will break `etwfe`. Unfortunately, this means that you will receive an email asking you to upload a new version to CRAN very soon.

This PR fixes all compatibility issues I could notice, and makes the tests slightly more resilient to future issues.

One recommendation: avoid using the column name "group" as in `test_baker.R`. This is a "reserved" word in `marginaleffects`; I will build some guardrails in the future, but for now this is dangerous.