### PR TITLE
tolerance for upcoming `marginaleffects`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Description: Convenience functions for implementing extended two-way
   fixed effect regressions a la Wooldridge (2021, 2022)
   <doi:10.2139/ssrn.3906345>, <doi:10.2139/ssrn.4183726>.
 License: MIT + file LICENSE
+Remotes: vincentarelbundock/marginaleffects
 Imports:
   fixest (>= 0.11.0),
   stats,

--- a/inst/tinytest/test_emfx.R
+++ b/inst/tinytest/test_emfx.R
@@ -1,4 +1,5 @@
 data("mpdta", package = "did")
+tol <- 5e-4
 # Add exponeniated employment outcome (for Poisson)
 mpdta$emp = exp(mpdta$lemp)
 
@@ -99,11 +100,11 @@ event_pre_known =
       term = c(".Dtreat", ".Dtreat", ".Dtreat", ".Dtreat", ".Dtreat", ".Dtreat", ".Dtreat", ".Dtreat"), 
       contrast = c("mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)"), 
       estimate = c(0, 0, 0, 0, -0.0332122037837577, -0.057345647925759, -0.137870386660868, -0.109539455365126), 
-      std.error = c(0, 0, 0, 0, 0.0133686711625469, 0.017153116591293, 0.0307945949146719, 0.0323218247953089), 
-      statistic = c(NaN, NaN, NaN, NaN, -2.48433096901983, -3.34316202076467, -4.47709693999516, -3.38902447676853), 
-      p.value = c(NaN, NaN, NaN, NaN, 0.0129795111476838, 0.000828295236610263, 7.56648975457471e-06, 0.000701417491255723), 
-      conf.low = c(0, 0, 0, 0, -0.0594143177835088, -0.0909651386673097, -0.198226683612125, -0.172889067878545), 
-      conf.high = c(0, 0, 0, 0, -0.00701008978400652, -0.0237261571842083, -0.0775140897096109, -0.0461898428517068), 
+      std.error = c(NA, NA, NA, NA, 0.0133686711625469, 0.017153116591293, 0.0307945949146719, 0.0323218247953089), 
+      statistic = c(NA, NA, NA, NA, -2.48433096901983, -3.34316202076467, -4.47709693999516, -3.38902447676853), 
+      p.value = c(NA, NA, NA, NA, 0.0129795111476838, 0.000828295236610263, 7.56648975457471e-06, 0.000701417491255723), 
+      conf.low = c(NA, NA, NA, NA, -0.0594143177835088, -0.0909651386673097, -0.198226683612125, -0.172889067878545), 
+      conf.high = c(NA, NA, NA, NA, -0.00701008978400652, -0.0237261571842083, -0.0775140897096109, -0.0461898428517068), 
       event = c(-4, -3, -2, -1, 0, 1, 2, 3), 
       predicted = c(8.58422618817666, 8.55899805002257, 8.59601363947542, 8.59460357323378, 8.55577814211513, 6.00937159256964, 5.31227368284963, 5.38860968779881), 
       predicted_hi = c(8.58422618817666, 8.55899805002257, 8.59601363947542, 8.59460357323378, 8.55577814211513, 6.00937159256964, 5.31227368284963, 5.38860968779881), 
@@ -144,11 +145,11 @@ e5 = emfx(m3, type = "event")
 e6 = emfx(m3, type = "event", post_only = FALSE)
 e7 = emfx(m3p, type = "event")
 for (col in c("estimate", "std.error", "conf.low", "conf.high")) {
-  expect_equivalent(e1[[col]], simple_known[[col]])
-  expect_equivalent(e2[[col]], simple_known[[col]])
-  expect_equivalent(e3[[col]], calendar_known[[col]])
-  expect_equivalent(e4[[col]], group_known[[col]])
-  expect_equivalent(e5[[col]], event_known[[col]])
-  expect_equivalent(e6[[col]], event_pre_known[[col]])
-  expect_equivalent(e7[[col]], event_pois_known[[col]])
+  expect_equivalent(e1[[col]], simple_known[[col]], tolerance = tol)
+  expect_equivalent(e2[[col]], simple_known[[col]], tolerance = tol)
+  expect_equivalent(e3[[col]], calendar_known[[col]], tolerance = tol)
+  expect_equivalent(e4[[col]], group_known[[col]], tolerance = tol)
+  expect_equivalent(e5[[col]], event_known[[col]], tolerance = tol)
+  expect_equivalent(e6[[col]], event_pre_known[[col]], tolerance = tol)
+  expect_equivalent(e7[[col]], event_pois_known[[col]], tolerance = tol)
 }

--- a/inst/tinytest/test_emfx_xvar.R
+++ b/inst/tinytest/test_emfx_xvar.R
@@ -1,4 +1,5 @@
 set.seed(123)
+tol <- 5e-4
 data("mpdta", package = "did")
 mpdta$xvar = rep(sample(1:3, size = 500, replace = TRUE), each = 5) # a categorical var for every id
 mpdta$emp = exp(mpdta$lemp)
@@ -398,11 +399,11 @@ e6 = emfx(x3x, type = "event", post_only = FALSE, collapse = TRUE)
 e7 = emfx(x3xp, type = "event", collapse = TRUE)
 
 for (col in c("estimate", "std.error", "conf.low", "conf.high")) {
-  expect_equivalent(e1[[col]], simple_known[[col]])
-  expect_equivalent(e2[[col]], simple_known[[col]])
-  expect_equivalent(e3[[col]], calendar_known[[col]])
-  expect_equivalent(e4[[col]], group_known[[col]])
-  expect_equivalent(e5[[col]], event_known[[col]])
-  expect_equivalent(e6[[col]], event_pre_known[[col]])
-  expect_equivalent(e7[[col]], event_pois_known[[col]])
+  expect_equivalent(e1[[col]], simple_known[[col]], tolerance = tol)
+  expect_equivalent(e2[[col]], simple_known[[col]], tolerance = tol)
+  expect_equivalent(e3[[col]], calendar_known[[col]], tolerance = tol)
+  expect_equivalent(e4[[col]], group_known[[col]], tolerance = tol)
+  expect_equivalent(e5[[col]], event_known[[col]], tolerance = tol)
+  expect_equivalent(e6[[col]], event_pre_known[[col]], tolerance = tol)
+  expect_equivalent(e7[[col]], event_pois_known[[col]], tolerance = tol)
 }


### PR DESCRIPTION
You've see the discussion about incorrect standard errors here: https://github.com/vincentarelbundock/marginaleffects/issues/684

I consider this a critical issue because it affects numerical accuracy, and I'd like to release a quick fix.

TBC, the issue does not appear to affect `etwfe` much, if at all. Unfortunately, changing the step size in my finite difference delta method code does change some digits and it will make your tests fail on CRAN. (Having to update my packages for tiny upstream changes like this is why I don't use CRAN for CI anymore.)

This PR adds `tolerance=5e-4` to some of your `expect_equivalent()` calls.

I know you just released a version because of me and that this is annoying. I'll do my best to check rev-deps and go slower in the future.