### PR TITLE
modelsummary 1.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
 Suggests:
   did,
   modelsummary,
+  gt,
   ggplot2,
   knitr,
   rmarkdown,

--- a/vignettes/etwfe.Rmd
+++ b/vignettes/etwfe.Rmd
@@ -13,6 +13,8 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 options(rmarkdown.html_vignette.check_title = FALSE)
+options(modelsummary_factory_default = "gt")
+
 fixest::setFixest_notes(FALSE)
 ```
 


### PR DESCRIPTION
`kableExtra` does not appear to be actively maintained and it causes some problems on `pkgdown` websites and for installation on some platforms. In version 1.4.0, `modelsummary` will no longer depend on `kableExtra`. Instead it will give the user a choice to install any of the supported table-making package, and offer a function to set a persistent default.

Call setting:

```r
modelsummary(model, output = "gt")
```

Persistent setting stays only for the current session:

```r
options(modelsummary_factory_default = "gt")
```

Persistent setting stays across sessions:

```r
config_modelsummary(factory_default = "gt")
```

Developers of packages that use `modelsummary` in vignettes need to add a table-making package to `Suggests`.

