### PR TITLE
marginaleffects 0.12.0

### DIFF
--- a/inst/tinytest/test_emfx.R
+++ b/inst/tinytest/test_emfx.R
@@ -144,6 +144,11 @@ e4 = emfx(m3, type = "group")
 e5 = emfx(m3, type = "event")
 e6 = emfx(m3, type = "event", post_only = FALSE)
 e7 = emfx(m3p, type = "event")
+
+# match order
+e3 = e3[order(e3$year),]
+e4 = e4[order(e4$first.treat),]
+
 for (col in c("estimate", "std.error", "conf.low", "conf.high")) {
   expect_equivalent(e1[[col]], simple_known[[col]], tolerance = tol)
   expect_equivalent(e2[[col]], simple_known[[col]], tolerance = tol)

--- a/inst/tinytest/test_xvar.R
+++ b/inst/tinytest/test_xvar.R
@@ -223,6 +223,8 @@ sim_es_known = structure(
 
 
 # Tests ----
+# match order
+sim_es = sim_es[order(sim_es$event, sim_es$te_grp),]
 
 for (col in c("estimate", "std.error", "conf.low", "conf.high")) {
   expect_equivalent(sim_att[[col]], sim_att_known[[col]], tolerance = tol)


### PR DESCRIPTION
Minor changes to tests to anticipate breaking changes in the upcoming `marginaleffects`.

Background: I've had to deal with *several* bugs related to the order of rows in `marginaleffects` output. In previous versions, I was trying to be clever to display rows "nicely" based on `by` and other arguments. Unfortunately, it turns out to be *very* tricky to handle the interplay of all the options: `by`, `hypothesis`, `posterior_draws`, etc.

I no longer trust the sorting code and will thus release a new version of `marginaleffects` which does not sort automatically. The breaking change is that the rows in the output will not always be the same as in previous versions.

This PR just adds a sort call to your tests so that comparisons match.

Not sure if you still run the tests on CRAN, but if so you'll have to make a new release. Sorry!