### PR TITLE
safer test

### DIFF
--- a/inst/tinytest/test_xvar.R
+++ b/inst/tinytest/test_xvar.R
@@ -34,7 +34,9 @@ hmod_att_known = structure(
   class = "data.frame", row.names = c(NA, -2L)
 )
 
-expect_equal(data.frame(hmod_att), hmod_att_known, tolerance = tol)
+for (col in intersect(colnames(hmod_att), colnames(hmod_att_known))) {
+  expect_equal(hmod_att[[col]], hmod_att_known[[col]], tolerance = tol)
+}
 
 # Simulation example ----
 


### PR DESCRIPTION
Snapshot-style tests should be avoided unless absolutely necessary, because as soon as anything changes they break.

`marginaleffects` 0.13.0 adds a new column to the output (S values) and breaks one of the expectations in `test_xvar.R`