### PR TITLE
Add Wild Cluster Bootstrap Support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,11 @@ Suggests:
   ggplot2,
   knitr,
   rmarkdown,
-  tinytest
+  tinytest, 
+  fwildclusterboot
+Remotes: 
+  kylebutts/fixest/tree/sparse-matrix
+  s3alfisc/fwildclusterboot/tree/etwfe-support
 Encoding: UTF-8
 RoxygenNote: 7.2.3
 URL: https://grantmcdermott.com/etwfe/

--- a/R/emfx.R
+++ b/R/emfx.R
@@ -26,15 +26,28 @@
 ##'   plotting an event-study); though be warned that this is strictly
 ##'   performative. This argument will only be evaluated if `type = "event"`.
 ##' @param bootstrap Logical. FALSE by default. Should inference be conducted 
-##'        via analytical standard errors or a  wild bootstrap? 
+##'        via analytical standard errors or a  wild bootstrap? To run the 
+##'        bootstrap, the `fwildclusterboot` package needs to be installed. 
+##'        If you want to run a bootstrap, you need to 
+##'        pass a number of bootstrap iterations via the `...` through
+##'        `emfx()`, e.g. `B = 9999`. The bootstrap is currently only supported 
+##'        for `type == 'simple'` and clustered errors. 
 ##' @param ... Additional arguments passed to
-##'   [`marginaleffects::marginaleffects`]. For example, you can pass `vcov =
-##'   FALSE` to dramatically speed up estimation times of the main marginal
-##'   effects (but at the cost of not getting any information about standard
-##'   errors; see Performance tips below). Another potentially useful
-##'   application is testing whether heterogeneous treatment effects (i.e. the
-##'   levels of any `xvar` covariate) are equal by invoking the `hypothesis`
-##'   argument, e.g. `hypothesis = "b1 = b2"`.
+##'   [`marginaleffects::marginaleffects`] or 
+##'   [`fwildclusterboot::boot_aggregate`] (the ladder is only relevant when 
+##'   `bootstrap = TRUE`). For example, you can pass `vcov = FALSE` 
+##'   to `marginaleffects` to dramatically speed up estimation times of the
+##'   main marginal effects (but at the cost of not getting any information 
+##'   about standard errors; see Performance tips below). 
+##'   Another potentially useful application is testing whether 
+##'   heterogeneous treatment effects (i.e. the levels of any `xvar` covariate)
+##'   are equal by invoking the `hypothesis` argument, e.g. 
+##'   `hypothesis = "b1 = b2"`. For the bootstrap, you can e.g. pass along the 
+##'   number of bootstrap iterations, the 
+##'   "bootcluster" variable (relevant for the subcluster bootstrap, via the 
+##'   `bootcluster` argument) or the number of threads to use 
+##'   (via the `nthreads` argument). For a comprehensive list 
+##'   of arguments, check `?fwildclusterboot::boot_aggregate()`.
 ##' @return A `slopes` object from the `marginaleffects` package.
 ##' @seealso [marginaleffects::slopes()]
 ##' @inherit etwfe return examples 
@@ -165,6 +178,13 @@ emfx = function(
       ) 
     }
     
+    if(mod$method != "feols"){
+      stop(
+        "Bootstrapping is only supported for models estimated", 
+        "via OLS / `feols()`."
+      )
+    }
+    
     if(type == "simple"){
       agg = c("ATT"="^.Dtreat:first.treat::[0-9]{4}:year::[0-9]{4}$")
     } else {
@@ -182,7 +202,7 @@ emfx = function(
     )
     if(ssc$fixef.K != "none"){
       warning(
-        paste0("The bootstrap does not support the ssc() argument fixef.K", fixef.K, ". Using `fixef.K = 'none' instead. This will lead to a slightly different non-bootstrapped t-statistic`, but will not affect bootstrapped p-values and CIs.")
+        paste0("The bootstrap does not support the ssc() argument `fixef.K='", fixef.K, "'`. Using `fixef.K='none' instead. This will lead to a slightly different non-bootstrapped t-statistic`, but will not affect bootstrapped p-values and CIs.")
       )
       fixef.K = "none"
     }
@@ -190,9 +210,9 @@ emfx = function(
     mfx <- fwildclusterboot::boot_aggregate(
       x = mod, 
       agg = agg, 
-      B = 9999, 
       ssc = boot_ssc, 
-      clustid = clustid
+      clustid = clustid, 
+      ...
     )
     
   }

--- a/R/etwfe.R
+++ b/R/etwfe.R
@@ -6,7 +6,6 @@
 ##' @param tvar Time variable. Can be a string (e.g., "year") or an expression
 ##'   (e.g., year).
 ##' @param gvar Group variable. Can be either a string (e.g., "first_treated")
-##'   or an expression (e.g., first_treated). In a staggered treatment setting,
 ##'   the group variable typically denotes treatment cohort.
 ##' @param data The data frame that you want to run ETWFE on.
 ##' @param ivar Optional index variable. Can be a string (e.g., "country") or an
@@ -148,7 +147,6 @@
 ##' 
 ##' # 2) Recover the treatment effects of interest with emfx().
 ##' 
-##' emfx(mod, type = "event") # dynamic ATE a la an event study
 ##' 
 ##' # Etc. Other aggregation type options are "simple" (the default), "group"
 ##' # and "calendar"
@@ -414,7 +412,8 @@ etwfe = function(
       xvar = xvar,
       ivar = ivar,
       gref = gref,
-      tref = tref
+      tref = tref, 
+      processed_data = data
       )
 
   ## Return ----

--- a/man/emfx.Rd
+++ b/man/emfx.Rd
@@ -10,6 +10,7 @@ emfx(
   by_xvar = "auto",
   collapse = "auto",
   post_only = TRUE,
+  bootstrap = FALSE,
   ...
 )
 }
@@ -44,14 +45,28 @@ dataset. But you may want to keep them for presentation reasons (e.g.,
 plotting an event-study); though be warned that this is strictly
 performative. This argument will only be evaluated if `type = "event"`.}
 
+\item{bootstrap}{Logical. FALSE by default. Should inference be conducted 
+via analytical standard errors or a  wild bootstrap? To run the 
+bootstrap, the `fwildclusterboot` package needs to be installed. 
+Note that at the moment, only the wild *clustered* bootstrap is 
+supported.}
+
 \item{...}{Additional arguments passed to
-[`marginaleffects::marginaleffects`]. For example, you can pass `vcov =
-FALSE` to dramatically speed up estimation times of the main marginal
-effects (but at the cost of not getting any information about standard
-errors; see Performance tips below). Another potentially useful
-application is testing whether heterogeneous treatment effects (i.e. the
-levels of any `xvar` covariate) are equal by invoking the `hypothesis`
-argument, e.g. `hypothesis = "b1 = b2"`.}
+[`marginaleffects::marginaleffects`] or 
+[`fwildclusterboot::boot_aggregate`] (only relevant when 
+`bootstrap = TRUE`). For example, you can pass `vcov = FALSE` 
+to `marginaleffects` to dramatically speed up estimation times of the
+main marginal effects (but at the cost of not getting any information 
+about standard errors; see Performance tips below). 
+Another potentially useful application is testing whether 
+heterogeneous treatment effects (i.e. the levels of any `xvar` covariate)
+are equal by invoking the `hypothesis` argument, e.g. 
+`hypothesis = "b1 = b2"`. For the bootstrap, you can e.g. pass along the 
+number of bootstrap iterations (the default is `B = 9999`), the 
+"bootcluster" variable (relevant for the subcluster bootstrap, via the 
+`bootcluster` argument) or the number of threads to use 
+(via the `nthreads` argument). For a comprehensive list 
+of arguments, check `?fwildclusterboot::boot_aggregate()`.}
 }
 \value{
 A `slopes` object from the `marginaleffects` package.
@@ -157,7 +172,6 @@ mod = etwfe(
 
 # 2) Recover the treatment effects of interest with emfx().
 
-emfx(mod, type = "event") # dynamic ATE a la an event study
 
 # Etc. Other aggregation type options are "simple" (the default), "group"
 # and "calendar"

--- a/man/etwfe.Rd
+++ b/man/etwfe.Rd
@@ -28,7 +28,6 @@ must take the value of 0 or 1, e.g. `y ~ 0`.}
 (e.g., year).}
 
 \item{gvar}{Group variable. Can be either a string (e.g., "first_treated")
-or an expression (e.g., first_treated). In a staggered treatment setting,
 the group variable typically denotes treatment cohort.}
 
 \item{data}{The data frame that you want to run ETWFE on.}
@@ -178,7 +177,6 @@ mod = etwfe(
 
 # 2) Recover the treatment effects of interest with emfx().
 
-emfx(mod, type = "event") # dynamic ATE a la an event study
 
 # Etc. Other aggregation type options are "simple" (the default), "group"
 # and "calendar"


### PR DESCRIPTION
This PR adds support for inference via a wild (cluster) bootstrap by adding a `bootstrap` argument to `etwfe` (only for OLS). If `bootstrap = TRUE`, etwfe will compute marginal effects by calling `fwildclusterboot::boot_aggregate()`, which is a copy of `fixest::aggregate()`. 

It currently depends on a fork of `fwildclusterboot`, which in itself depends on a fork of `fixest` by @kylebutts, which introduces support or sparse model matrices. In other words, merging this PR will require another [PR](https://github.com/lrberge/fixest/pull/418) to be merged into fixest. 

At the moment, this PR simply 

-  adds a `bootstrap` argument to `emfx`. If `bootstrap = TRUE`, it will run a wild cluster bootstrap via the `fwildclusterboot` package
- in consequence, `fwildclusterboot` is added as a (soft) dependency in `Suggests`
- at the moment, only `type = "simple"` and the "clustered" bootstrap are supported

The PR still
- [ ]  ...requires @kylebutts's PR to be merged into `fixest`
- [ ] ... and `fwildclusterboot` being updated afterwards
- [ ] ... lacks support for the heteroskedastic bootstrap
- [ ] .... lacks some defensive checks 
- [ ] ... lacks unit tests 
- [ ] ... lacks documentation in the vignette

It is also worth discussing how to unify the output, i.e. running `marginaleffects` will return a `marginaleffects` object, while running the bootstrap will simply return a `data.frame`.

Here is some example code: 

```r
library(devtools)
install_github("https://github.com/s3alfisc/fwildclusterboot/tree/etwfe-support")
# this should install kyle's fork of fixest, if not, do it manually
#install_github("https://github.com/kylebutts/fixest/tree/sparse-matrix")

library(etwfe)
library(fwildclusterboot)
data("mpdta", package="did")

mod = etwfe(
  fml = lemp ~ lpop,
  tvar  = year,
  gvar = first.treat,
  data = mpdta,
  #se = "hetero",
  vcov = ~countyreal, 
  ssc = fixest::ssc(adj = FALSE, cluster.adj = FALSE)
)
#names(coef(mod))

emfx(mod)
# Term                 Contrast .Dtreat Estimate Std. Error
# .Dtreat mean(TRUE) - mean(FALSE)    TRUE  -0.0506     0.0124
# z Pr(>|z|)    S  2.5 %  97.5 %
#   -4.08   <0.001 14.4 -0.075 -0.0263
emfx(mod, bootstrap = TRUE, B = 99999, nthreads = 2)
# Run the wild bootstrap: this might take some time...(but hopefully not too much time =) ).
# |======================================================| 100%        Estimate   t value    Pr(>|t|)     [0.025%     0.975%]
# [1,] -0.05062703 -4.078845 6.00006e-05 -0.07550813 -0.02580929
# Warning messages:
#   1: In emfx(mod, bootstrap = TRUE, B = 99999, nthreads = 2) :
#   The bootstrap does not support the ssc() argument `fixef.K='none'`. Using `fixef.K='none' instead. This will lead to a slightly different non-bootstrapped t-statistic`, but will not affect bootstrapped p-values and CIs.
# 2: Matrix inversion failure: Using a generalized inverse instead.
# Check the produced t-statistic, does it match the one of your
# regression package (under the same small sample correction)? If
# yes, this is likely not something to worry about. 
```
@jtorcasso fyi