### PR TITLE
Add `emfx(..., predict)` arg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests:
   rmarkdown,
   tinytest
 Encoding: UTF-8
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 URL: https://grantmcdermott.com/etwfe/
 BugReports: https://github.com/grantmcdermott/etwfe/issues
 VignetteBuilder: knitr

--- a/R/emfx.R
+++ b/R/emfx.R
@@ -30,6 +30,15 @@
 ##'   that behaviour via `TRUE` is _strictly_ performative: the "zero" treatment
 ##'   effects for any pre-treatment periods is purely an artefact of the
 ##'   estimation setup.
+##' @param predict Character. The type (scale) of prediction used to compute the
+##'   marginal effects. If `"response"` (the default), then the output is at the
+##'   level of the response variable, i.e. it is the expected predictor
+##'   \eqn{E(Y|X)}. If `type = "link"`, the value returned is the linear
+##'   predictor of the fitted model, i.e. \eqn{X\cdot \beta}. The difference
+##'   should only matter for nonlinear models. (Note: This argument is typically
+##'   called `type` when use in \code{\link[stats]{predict}} or
+##'   \code{\link[marginaleffects]{slopes}}, but we rename it here to avoid a
+##'   clash with the top-level `type` argument above.)
 ##' @param ... Additional arguments passed to
 ##'   [`marginaleffects::slopes`]. For example, you can pass `vcov =
 ##'   FALSE` to dramatically speed up estimation times of the main marginal
@@ -52,6 +61,7 @@ emfx = function(
     by_xvar = "auto",
     collapse = "auto",
     post_only = TRUE,
+    predict = c("response", "link"),
     ...
 ) {
   
@@ -59,6 +69,7 @@ emfx = function(
 
   .Dtreat = NULL
   type = match.arg(type)
+  predict = match.arg(predict)
   etwfe_attr = attr(object, "etwfe")
   gvar = etwfe_attr[["gvar"]]
   tvar = etwfe_attr[["tvar"]]
@@ -162,6 +173,7 @@ emfx = function(
     wts = "N",
     variables = ".Dtreat",
     by = by_var,
+    type = predict,
     ...
   )
 

--- a/inst/tinytest/test_emfx.R
+++ b/inst/tinytest/test_emfx.R
@@ -135,6 +135,26 @@ event_pois_known =
     model_type = "etwfe"
   )
 
+event_pois_link_known = structure(
+  list(
+    term = c(".Dtreat", ".Dtreat", ".Dtreat", ".Dtreat"),
+    contrast = c("mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)", "mean(TRUE) - mean(FALSE)"),
+    event = c(0, 1, 2, 3),
+    estimate = c(-0.0325653634932165, -0.0675071047000078, -0.13297134493384, -0.117022779216551),
+    std.error = c(0.012852983394089, 0.018400421028425, 0.0237301206925325, 0.0225051243923356),
+    statistic = c(-2.53368128587118, -3.6687804369108, -5.60348371829748, -5.19982814475821),
+    p.value = c(0.0112871339541832, 0.000243710265677802, 2.10085859293411e-08, 1.99472873101063e-07),
+    s.value = c(6.46917698842941, 12.002545357333, 25.5044457004379, 22.2573041007391),
+    conf.low = c(-0.0577567480395224, -0.103571267216094, -0.179481526839992, -0.161132012493123),
+    conf.high = c(-0.00737397894691056, -0.0314429421839213, -0.0864611630276877, -0.0729135459399795),
+    predicted_lo = c(8.59999694263988, 6.24569002837391, 5.68530511263303, 5.70993143759263),
+    predicted_hi = c(8.53326519229116, 6.15518645002986, 5.52751652841592, 5.57772190861547),
+    predicted = c(8.53326519229116, 6.15518645002986, 5.52751652841592, 5.57772190861547)
+  ),
+  row.names = c(NA, -4L),
+  class = c("slopes", "marginaleffects", "data.frame")
+)
+
 # Tests ----
 
 e1 = emfx(m3)
@@ -144,6 +164,7 @@ e4 = emfx(m3, type = "group")
 e5 = emfx(m3, type = "event")
 e6 = emfx(m3, type = "event", post_only = FALSE)
 e7 = emfx(m3p, type = "event")
+e8 = emfx(m3p, type = "event", predict = "link")
 
 # match order
 e3 = e3[order(e3$year),]
@@ -157,4 +178,5 @@ for (col in c("estimate", "std.error", "conf.low", "conf.high")) {
   expect_equivalent(e5[[col]], event_known[[col]], tolerance = tol)
   expect_equivalent(e6[[col]], event_pre_known[[col]], tolerance = tol)
   expect_equivalent(e7[[col]], event_pois_known[[col]], tolerance = tol)
+  expect_equivalent(e8[[col]], event_pois_link_known[[col]], tolerance = tol)
 }

--- a/man/emfx.Rd
+++ b/man/emfx.Rd
@@ -10,6 +10,7 @@ emfx(
   by_xvar = "auto",
   collapse = "auto",
   post_only = TRUE,
+  predict = c("response", "link"),
   ...
 )
 }
@@ -48,6 +49,16 @@ recognises that you may still want to keep them for presentation purposes
 that behaviour via \code{TRUE} is \emph{strictly} performative: the "zero" treatment
 effects for any pre-treatment periods is purely an artefact of the
 estimation setup.}
+
+\item{predict}{Character. The type (scale) of prediction used to compute the
+marginal effects. If \code{"response"} (the default), then the output is at the
+level of the response variable, i.e. it is the expected predictor
+\eqn{E(Y|X)}. If \code{type = "link"}, the value returned is the linear
+predictor of the fitted model, i.e. \eqn{X\cdot \beta}. The difference
+should only matter for nonlinear models. (Note: This argument is typically
+called \code{type} when use in \code{\link[stats]{predict}} or
+\code{\link[marginaleffects]{slopes}}, but we rename it here to avoid a
+clash with the top-level \code{type} argument above.)}
 
 \item{...}{Additional arguments passed to
 \code{\link[marginaleffects:slopes]{marginaleffects::slopes}}. For example, you can pass \code{vcov = FALSE} to dramatically speed up estimation times of the main marginal


### PR DESCRIPTION
See https://github.com/grantmcdermott/etwfe/issues/47#issuecomment-2452756488.

Internally passed as `marginaleffects(..., type = predict)` to avoid the top-line clash with `emfx(..., type)`.