### PR TITLE
test fix in advance of marginaleffects 0.24.0

### DIFF
--- a/inst/tinytest/test_xvar.R
+++ b/inst/tinytest/test_xvar.R
@@ -34,7 +34,8 @@ hmod_att_known = structure(
   class = "data.frame", row.names = c(NA, -2L)
 )
 
-for (col in intersect(colnames(hmod_att), colnames(hmod_att_known))) {
+cols = c("estimate", "std.error", "statistic", "p.value", "conf.low", "conf.high")
+for (col in cols) {
   expect_equal(hmod_att[[col]], hmod_att_known[[col]], tolerance = tol)
 }
 


### PR DESCRIPTION
I'm not sure why the test is failing with the upcoming `marginaleffects`, but this seems to fix it.