### PR TITLE
Innocuous modification in test_etwfe.R to accomodate fixest v0.14.0

### DIFF
--- a/inst/tinytest/test_etwfe.R
+++ b/inst/tinytest/test_etwfe.R
@@ -409,6 +409,16 @@ m3p_known = structure(
   vcov_type = "Clustered (countyreal)"
 )
 
+if(packageVersion("fixest") < "0.14.0"){
+  attr(m1_known, "type") = attr(m1_known, "vcov_type")
+  attr(m2_known, "type") = attr(m2_known, "vcov_type")
+  attr(m3_known, "type") = attr(m3_known, "vcov_type")
+  attr(m3p_known, "type") = attr(m3p_known, "vcov_type")
+  
+  attr(m1_known, "vcov_type") = attr(m2_known, "vcov_type") = NULL
+  attr(m3_known, "vcov_type") = attr(m3p_known, "vcov_type") = NULL
+}
+
 
 # Tests ----
 

--- a/inst/tinytest/test_etwfe.R
+++ b/inst/tinytest/test_etwfe.R
@@ -50,7 +50,7 @@ m1_known = structure(
     ),
     c("Estimate", "Std. Error", "t value", "Pr(>|t|)")
   ),
-  type = "Clustered (countyreal)"
+  vcov_type = "Clustered (countyreal)"
 )
 
 m2_known = structure(
@@ -122,7 +122,7 @@ m2_known = structure(
     ),
     c("Estimate", "Std. Error", "t value", "Pr(>|t|)")
   ),
-  type = "Clustered (countyreal)"
+  vcov_type = "Clustered (countyreal)"
 )
 
 m3_known = structure(
@@ -244,7 +244,7 @@ m3_known = structure(
     ),
     c("Estimate", "Std. Error", "t value", "Pr(>|t|)")
   ),
-  type = "Clustered (countyreal)"
+  vcov_type = "Clustered (countyreal)"
 )
 
 m3p_known = structure(
@@ -406,7 +406,7 @@ m3p_known = structure(
     ),
     c("Estimate", "Std. Error", "z value", "Pr(>|z|)")
   ),
-  type = "Clustered (countyreal)"
+  vcov_type = "Clustered (countyreal)"
 )
 
 


### PR DESCRIPTION
In fixest v0.14.0, coeftable's attribute `type` becomes `vcov_type` to increase clarity.

This leads to a few tests in test_etwfe.R to fail. This PR simply changes the hard coded 'type' into 'vcov_type'.

I hope that's OK Grant (I don't think it's useful to update the news.md for this, it's super minor).